### PR TITLE
chore: add emulator check to avoid calling getPowerState for sims

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -102,6 +102,15 @@ export const getNonConnectivityInfo = async (): Promise<
  * @returns A BatteryVibe object that contains all data related to Battery Info
  */
 export const getBatteryInfo = async (): Promise<BatteryVibe> => {
+  const isEmulator = DeviceInfo.isEmulatorSync();
+  if (isEmulator) {
+    return {
+      batteryLevel: null,
+      batteryState: null,
+      lowPowerMode: null,
+    };
+  }
+
   const { batteryLevel, batteryState, lowPowerMode } =
     await DeviceInfo.getPowerState();
 


### PR DESCRIPTION
When running vibe-check in a simulator, this log is output every time we check the vibes:

```
WARN  Battery state `unknown` and monitoring disabled, this is normal for simulators and tvOS.
```

This adds a check to skip the call to `getPowerState` for a simulator to silence the log.